### PR TITLE
fix(ci): allow push events in build workflow if conditions

### DIFF
--- a/.github/workflows/build-api-image.yml
+++ b/.github/workflows/build-api-image.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     # Run on master push (for staging) or release (for production) or manual dispatch.
     if: |
+      (github.event_name == 'push') ||
       (github.event_name == 'workflow_dispatch') ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
       (github.event_name == 'release' && github.event.action == 'published')

--- a/.github/workflows/build-web-images.yml
+++ b/.github/workflows/build-web-images.yml
@@ -29,6 +29,7 @@ jobs:
     name: Build ${{ matrix.app }}
     runs-on: ubuntu-latest
     if: |
+      github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'release' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')


### PR DESCRIPTION
## Summary
- The previous commit added `push` triggers to `build-api-image.yml` and `build-web-images.yml` for the `staging` branch, but the job-level `if:` conditions were not updated to include `push` events — causing the jobs to be skipped on every direct push.
- This adds `github.event_name == 'push'` to the `if:` block in both workflows.

## Test plan
- [ ] Merge to staging and verify both build workflows run (not skipped) on the resulting push event