### PR TITLE
feat(docker): run drizzle migrations on container startup for wxwatch and wxproducts

### DIFF
--- a/apps/web/wxproducts/Dockerfile
+++ b/apps/web/wxproducts/Dockerfile
@@ -49,8 +49,11 @@ COPY --from=builder --chown=nextjs:nodejs /app/apps/web/wxproducts/public ./apps
 COPY --from=builder --chown=nextjs:nodejs /app/apps/web/wxproducts/drizzle ./apps/web/wxproducts/drizzle
 COPY --from=builder --chown=nextjs:nodejs /app/apps/web/wxproducts/scripts ./apps/web/wxproducts/scripts
 
+RUN printf '#!/bin/sh\nset -e\nnode apps/web/wxproducts/scripts/migrate.mjs\nexec node apps/web/wxproducts/server.js\n' > /entrypoint.sh \
+    && chmod +x /entrypoint.sh
+
 USER nextjs
 EXPOSE 3005
 ENV PORT=3005
 ENV HOSTNAME=0.0.0.0
-CMD ["node", "apps/web/wxproducts/server.js"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/apps/web/wxwatch/Dockerfile
+++ b/apps/web/wxwatch/Dockerfile
@@ -48,8 +48,11 @@ COPY --from=builder --chown=nextjs:nodejs /app/apps/web/wxwatch/public ./apps/we
 COPY --from=builder --chown=nextjs:nodejs /app/apps/web/wxwatch/drizzle ./apps/web/wxwatch/drizzle
 COPY --from=builder --chown=nextjs:nodejs /app/apps/web/wxwatch/scripts ./apps/web/wxwatch/scripts
 
+RUN printf '#!/bin/sh\nset -e\nnode apps/web/wxwatch/scripts/migrate.mjs\nexec node apps/web/wxwatch/server.js\n' > /entrypoint.sh \
+    && chmod +x /entrypoint.sh
+
 USER nextjs
 EXPOSE 3002
 ENV PORT=3002
 ENV HOSTNAME=0.0.0.0
-CMD ["node", "apps/web/wxwatch/server.js"]
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- Adds an entrypoint script to `web-wxwatch` and `web-wxproducts` Docker images that runs `migrate.mjs` before starting the Next.js server
- Uses `exec` so the Node process inherits PID 1 and handles signals correctly

## Test plan
- [ ] Merge to staging and verify `Build Web App Images` passes for both apps
- [ ] On deploy, confirm migration logs appear before server startup