### PR TITLE
fix(ci): use github.ref_name for push events to determine image tag

### DIFF
--- a/.github/workflows/build-api-image.yml
+++ b/.github/workflows/build-api-image.yml
@@ -75,6 +75,17 @@ jobs:
             echo "primary_tag=$TAG" >> $GITHUB_OUTPUT
             echo "version_tag=" >> $GITHUB_OUTPUT
             echo "Building $TAG tag (manual trigger)"
+          elif [ "${{ github.event_name }}" == "push" ]; then
+            BRANCH="${{ github.ref_name }}"
+            if [ "$BRANCH" == "staging" ]; then
+              echo "primary_tag=staging" >> $GITHUB_OUTPUT
+              echo "version_tag=" >> $GITHUB_OUTPUT
+              echo "Building staging tag"
+            else
+              echo "primary_tag=latest" >> $GITHUB_OUTPUT
+              echo "version_tag=" >> $GITHUB_OUTPUT
+              echo "Building latest tag for main branch"
+            fi
           else
             # workflow_run — branch determines staging vs production
             BRANCH="${{ github.event.workflow_run.head_branch }}"

--- a/.github/workflows/build-web-images.yml
+++ b/.github/workflows/build-web-images.yml
@@ -101,6 +101,19 @@ jobs:
               API_URL="https://api.barrels.gd"
               ENVIRONMENT="production"
             fi
+          elif [ "${{ github.event_name }}" == "push" ]; then
+            BRANCH="${{ github.ref_name }}"
+            if [ "$BRANCH" == "staging" ]; then
+              TAG="staging"
+              VERSION=""
+              API_URL="https://api.staging.barrels.gd"
+              ENVIRONMENT="staging"
+            else
+              TAG="latest"
+              VERSION=""
+              API_URL="https://api.barrels.gd"
+              ENVIRONMENT="production"
+            fi
           else
             # workflow_run — branch determines staging vs production
             BRANCH="${{ github.event.workflow_run.head_branch }}"


### PR DESCRIPTION
## Summary
- Both build workflows fell through to the `workflow_run` branch of the tag logic when triggered by a `push` event, reading `github.event.workflow_run.head_branch` which is empty for push events — causing all push-triggered builds to tag images as `latest` instead of `staging`
- Adds an explicit `push` case using `github.ref_name` to determine the correct tag

## Test plan
- [ ] Merge to staging and verify API image is pushed as `:staging`
- [ ] Re-run deploy workflow and confirm it succeeds