### PR TITLE
fix(db): connect to postgres maintenance db in init script, increase health check start_period

### DIFF
--- a/infra/docker/docker-compose.staging.yml
+++ b/infra/docker/docker-compose.staging.yml
@@ -34,7 +34,7 @@ services:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 10s
       retries: 5
-      start_period: 30s
+      start_period: 60s
       timeout: 10s
     networks:
       - grenmet-staging

--- a/infra/postgres/init-databases.sh
+++ b/infra/postgres/init-databases.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 create_db() {
   local user="$1" password="$2" db="$3"
-  psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-SQL
+  psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname postgres <<-SQL
     DO \$\$
     BEGIN
       IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '$user') THEN


### PR DESCRIPTION
## Summary
- `init-databases.sh`: explicitly pass `--dbname postgres` to the first `psql` call so it always connects to the maintenance database regardless of what `POSTGRES_USER` is set to — previously it defaulted to the username which crashed the init script with `database "app" does not exist`
- `docker-compose.staging.yml`: increase DB health check `start_period` from 30s to 60s to survive a crash-restart cycle during first init

## Test plan
- [ ] Merge to staging, run `gh workflow run deploy-staging.yml --ref staging`, confirm DB starts healthy and deploy completes