### PR TITLE
feat(spicewx): implement GrenMet-v1 mobile design

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -36,7 +36,14 @@
       "Bash(grep -E \"\\\\.ts$\")",
       "Bash(pnpm fix:*)",
       "Bash(pnpm check:fix)",
-      "Bash(gh pr *)"
+      "Bash(gh pr *)",
+      "mcp__figma__generate_figma_design",
+      "mcp__figma__use_figma",
+      "mcp__figma__get_design_context",
+      "mcp__figma__get_screenshot",
+      "Read(//mnt/c/Users/eugin/OneDrive/DEV/grenmet/**)",
+      "Read(//mnt/c/Users/eugin/OneDrive/DEV/grenmet/apps/web/spicewx/**)",
+      "Bash(node -e \"console.log\\(require\\('/mnt/c/Users/eugin/OneDrive/DEV/grenmet/node_modules/lucide-react/package.json'\\).version\\)\")"
     ]
   }
 }

--- a/apps/web/spicewx/src/app/(weather)/[date]/page.tsx
+++ b/apps/web/spicewx/src/app/(weather)/[date]/page.tsx
@@ -1,7 +1,16 @@
 import { notFound } from "next/navigation";
-import { WeatherConditions } from "@/components/weather-conditions";
-import { CONDITIONS, WARNINGS } from "@/lib/forecast-data";
+import { TuesdayMay19Forecast } from "@/components/forecasts/tuesday-may-19";
+import { WednesdayMay20Forecast } from "@/components/forecasts/wednesday-may-20";
+import { ThursdayMay21Forecast } from "@/components/forecasts/thursday-may-21";
+import { FridayMay22Forecast } from "@/components/forecasts/friday-may-22";
 import { getUpcomingDaySlugs } from "@/lib/forecast-days";
+
+const FORECAST_COMPONENTS: Record<string, () => React.JSX.Element> = {
+  "2026-05-19": TuesdayMay19Forecast,
+  "2026-05-20": WednesdayMay20Forecast,
+  "2026-05-21": ThursdayMay21Forecast,
+  "2026-05-22": FridayMay22Forecast,
+};
 
 interface Props {
   params: Promise<{ date: string }>;
@@ -14,17 +23,11 @@ export default async function ForecastDayPage({ params }: Props) {
     notFound();
   }
 
-  const d = new Date(`${date}T12:00:00`);
-  const displayDate = d.toLocaleString("en-US", {
-    day: "numeric",
-    month: "long",
-  });
+  const ForecastComponent = FORECAST_COMPONENTS[date];
 
-  return (
-    <WeatherConditions
-      conditions={CONDITIONS}
-      title={`Key Conditions — ${displayDate}`}
-      warnings={WARNINGS}
-    />
-  );
+  if (!ForecastComponent) {
+    notFound();
+  }
+
+  return <ForecastComponent />;
 }

--- a/apps/web/spicewx/src/app/(weather)/[date]/page.tsx
+++ b/apps/web/spicewx/src/app/(weather)/[date]/page.tsx
@@ -1,8 +1,8 @@
 import { notFound } from "next/navigation";
+import { FridayMay22Forecast } from "@/components/forecasts/friday-may-22";
+import { ThursdayMay21Forecast } from "@/components/forecasts/thursday-may-21";
 import { TuesdayMay19Forecast } from "@/components/forecasts/tuesday-may-19";
 import { WednesdayMay20Forecast } from "@/components/forecasts/wednesday-may-20";
-import { ThursdayMay21Forecast } from "@/components/forecasts/thursday-may-21";
-import { FridayMay22Forecast } from "@/components/forecasts/friday-may-22";
 import { getUpcomingDaySlugs } from "@/lib/forecast-days";
 
 const FORECAST_COMPONENTS: Record<string, () => React.JSX.Element> = {

--- a/apps/web/spicewx/src/app/(weather)/layout.tsx
+++ b/apps/web/spicewx/src/app/(weather)/layout.tsx
@@ -1,8 +1,8 @@
-import { Alerts } from "@/components/alerts";
+import { CurrentAlertsAccordion } from "@/components/current-alerts-accordion";
 import { GmsNews } from "@/components/gms-news";
 import { News } from "@/components/news";
-import { PageHeader } from "@/components/page-header";
 import { WeatherDateNav } from "@/components/weather-date-nav";
+import { WARNINGS } from "@/lib/forecast-data";
 
 export default function WeatherLayout({
   children,
@@ -10,23 +10,21 @@ export default function WeatherLayout({
   children: React.ReactNode;
 }) {
   return (
-    <>
-      <PageHeader title="Your spice weather" />
+    <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <h1 className="mb-4 pt-6 font-bold text-3xl text-gm-navy">
+        Your spice weather
+      </h1>
 
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="lg:hidden">
-          <Alerts />
-        </div>
+      <CurrentAlertsAccordion warnings={WARNINGS} />
 
-        <div className="mb-4 flex flex-col overflow-hidden rounded-xl border border-gm-border bg-white shadow-sm lg:flex-row">
-          <WeatherDateNav />
-          {children}
-        </div>
-
-        <GmsNews />
-
-        <News />
+      <div className="mb-4 overflow-hidden border border-gm-border">
+        <WeatherDateNav />
+        {children}
       </div>
-    </>
+
+      <GmsNews />
+
+      <News />
+    </div>
   );
 }

--- a/apps/web/spicewx/src/app/(weather)/page.tsx
+++ b/apps/web/spicewx/src/app/(weather)/page.tsx
@@ -1,12 +1,6 @@
 import { WeatherConditions } from "@/components/weather-conditions";
-import { TODAY_CONDITIONS, WARNINGS } from "@/lib/forecast-data";
+import { TODAY_CONDITIONS } from "@/lib/forecast-data";
 
 export default function NowPage() {
-  return (
-    <WeatherConditions
-      conditions={TODAY_CONDITIONS}
-      title="Current Conditions"
-      warnings={WARNINGS}
-    />
-  );
+  return <WeatherConditions conditions={TODAY_CONDITIONS} />;
 }

--- a/apps/web/spicewx/src/app/(weather)/page.tsx
+++ b/apps/web/spicewx/src/app/(weather)/page.tsx
@@ -1,10 +1,10 @@
 import { WeatherConditions } from "@/components/weather-conditions";
-import { CONDITIONS, WARNINGS } from "@/lib/forecast-data";
+import { TODAY_CONDITIONS, WARNINGS } from "@/lib/forecast-data";
 
 export default function NowPage() {
   return (
     <WeatherConditions
-      conditions={CONDITIONS}
+      conditions={TODAY_CONDITIONS}
       title="Current Conditions"
       warnings={WARNINGS}
     />

--- a/apps/web/spicewx/src/app/globals.css
+++ b/apps/web/spicewx/src/app/globals.css
@@ -1,5 +1,8 @@
 @import "tailwindcss";
 
+/* Dark mode only activates via explicit .dark class — never from system preference */
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme inline {
   --font-sans: var(--font-inter);
 
@@ -71,6 +74,7 @@
   --destructive-foreground: #ffffff;
   --border: var(--gm-border);
   --ring: var(--gm-blue);
+  color-scheme: light;
 }
 
 body {

--- a/apps/web/spicewx/src/components/current-alerts-accordion.tsx
+++ b/apps/web/spicewx/src/components/current-alerts-accordion.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { ChevronDownIcon } from "@heroicons/react/24/outline";
+import { ExclamationTriangleIcon } from "@heroicons/react/24/solid";
+import { useState } from "react";
+import type { Warning } from "@/lib/forecast-data";
+import { cn } from "@/lib/utils";
+
+interface CurrentAlertsAccordionProps {
+  warnings: Warning[];
+}
+
+export function CurrentAlertsAccordion({
+  warnings,
+}: CurrentAlertsAccordionProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="mb-4 flex flex-col">
+      {/* Header */}
+      <button
+        aria-expanded={open}
+        className="flex h-[45px] w-full shrink-0 items-center justify-between rounded-tl-[6px] rounded-tr-[6px] border-[1.5px] border-gm-navy bg-gm-risk-yellow px-[18px]"
+        onClick={() => setOpen(!open)}
+        type="button"
+      >
+        <span className="flex items-center gap-[14px] font-bold text-[17px] text-gray-900">
+          <ExclamationTriangleIcon className="size-[28px] shrink-0" />
+          Current alerts
+        </span>
+        <ChevronDownIcon
+          className={cn(
+            "size-[28px] text-gray-900 transition-transform duration-200",
+            open && "rotate-180"
+          )}
+        />
+      </button>
+
+      {/* Expanded panel */}
+      {open && (
+        <div className="w-full rounded-br-[6px] rounded-bl-[6px] border border-gm-navy bg-gm-navy px-[24px] pt-[22px] pb-[24px]">
+          {warnings.map((w) => (
+            <div
+              className={cn(
+                "flex h-[30px] items-center gap-[16px] text-[16px]",
+                w.count === 0 && "opacity-35"
+              )}
+              key={w.region}
+            >
+              <span className="w-[34px] shrink-0 font-semibold text-gm-risk-yellow">
+                {w.count}
+              </span>
+              <span className="text-white">{w.region}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/spicewx/src/components/footer.tsx
+++ b/apps/web/spicewx/src/components/footer.tsx
@@ -15,11 +15,11 @@ export const Footer = () => (
       <div className="flex flex-col items-start gap-6 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
           <Image
-            alt="GrenMet"
-            className="h-9 w-auto"
-            height={36}
+            alt="Grenada Meteorological Service"
+            className=""
+            height={40}
             src="/gmslogos/logo-primary-navy.png"
-            width={108}
+            width={180}
           />
         </div>
 

--- a/apps/web/spicewx/src/components/footer.tsx
+++ b/apps/web/spicewx/src/components/footer.tsx
@@ -1,50 +1,148 @@
 import Image from "next/image";
 
-const links = [
-  { label: "Forecasts", href: "/forecasts" },
-  { label: "Warnings", href: "/warnings" },
-  { label: "Marine", href: "/marine" },
-  { label: "Aviation", href: "/aviation" },
-  { label: "About GMS", href: "/about" },
-  { label: "Contact", href: "/contact" },
+const LINK_ROWS = [
+  [
+    { label: "About GMS", href: "/about" },
+    { label: "Contact", href: "/contact" },
+  ],
+  [
+    { label: "GMS Weather app", href: "/weather-app" },
+    { label: "Glossary", href: "/glossary" },
+  ],
+  [
+    { label: "Events", href: "/events" },
+    { label: "Website help", href: "/help" },
+  ],
+  [{ label: "News and media", href: "/news" }],
 ];
 
-export const Footer = () => (
-  <footer className="border-gm-border border-t text-muted-foreground">
-    <div className="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
-      <div className="flex flex-col items-start gap-6 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-3">
-          <Image
-            alt="Grenada Meteorological Service"
-            className=""
-            height={40}
-            src="/gmslogos/logo-primary-navy.png"
-            width={180}
-          />
-        </div>
+const SOCIAL = [
+  {
+    label: "X / Twitter",
+    abbr: "X",
+    href: "https://x.com",
+    size: "text-[15px]",
+  },
+  {
+    label: "Facebook",
+    abbr: "f",
+    href: "https://facebook.com",
+    size: "text-[18px]",
+  },
+  {
+    label: "Instagram",
+    abbr: "ig",
+    href: "https://instagram.com",
+    size: "text-[12px]",
+  },
+  {
+    label: "YouTube",
+    abbr: "yt",
+    href: "https://youtube.com",
+    size: "text-[12px]",
+  },
+  {
+    label: "LinkedIn",
+    abbr: "in",
+    href: "https://linkedin.com",
+    size: "text-[13px]",
+  },
+];
 
-        <nav aria-label="Footer navigation">
-          <ul className="flex flex-wrap gap-x-6 gap-y-2">
-            {links.map((link) => (
-              <li key={link.label}>
-                <a
-                  className="text-sm transition-colors hover:text-gm-navy"
-                  href={link.href}
-                >
-                  {link.label}
-                </a>
-              </li>
+const LEGAL_LINKS = [
+  { label: "Sitemap", href: "/sitemap" },
+  { label: "Disclaimer", href: "/disclaimer" },
+  { label: "Privacy", href: "/privacy" },
+  { label: "Accessibility", href: "/accessibility" },
+];
+
+const DIVIDER = <div className="h-px w-full bg-[#d0d5dd]" />;
+
+export function Footer() {
+  return (
+    <footer className="flex flex-col bg-white">
+      {DIVIDER}
+
+      {/* Links */}
+      <div className="flex flex-col gap-[4px] px-[24px] py-[8px]">
+        {LINK_ROWS.map((row) => (
+          <div
+            className="flex gap-[16px] py-[6px]"
+            key={row.map((l) => l.label).join()}
+          >
+            {row.map((link) => (
+              <a
+                className="flex-1 text-[#101828] text-[19px] underline"
+                href={link.href}
+                key={link.label}
+              >
+                {link.label}
+              </a>
             ))}
-          </ul>
-        </nav>
+          </div>
+        ))}
       </div>
 
-      <div className="mt-8 border-gm-border border-t pt-6">
-        <p className="text-xs">
-          &copy; {new Date().getFullYear()} Grenada Meteorological Service. All
-          rights reserved.
+      {DIVIDER}
+
+      {/* Social */}
+      <div className="flex gap-[12px] px-[24px] py-[28px]">
+        {SOCIAL.map((s) => (
+          <a
+            aria-label={s.label}
+            className={`flex size-[44px] items-center justify-center rounded-[22px] bg-[#1a2a6b] font-semibold text-white ${s.size}`}
+            href={s.href}
+            key={s.label}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {s.abbr}
+          </a>
+        ))}
+      </div>
+
+      {DIVIDER}
+
+      {/* Institutional lockup */}
+      <div className="flex flex-col gap-[10px] px-[24px] py-[28px]">
+        <Image
+          alt="Grenada Meteorological Service"
+          height={43}
+          src="/gmslogos/logo-primary-navy.png"
+          width={180}
+        />
+        <p className="font-semibold text-[#101828] text-[13px]">
+          Grenada Airports Authority
+        </p>
+        <p className="text-[#71717b] text-[12px]">
+          Grenada Meteorological Service
         </p>
       </div>
-    </div>
-  </footer>
-);
+
+      {DIVIDER}
+
+      {/* Legal links */}
+      <div className="flex gap-[20px] px-[24px] py-[20px]">
+        {LEGAL_LINKS.map((link) => (
+          <a
+            className="shrink-0 text-[#71717b] text-[12px] underline"
+            href={link.href}
+            key={link.label}
+          >
+            {link.label}
+          </a>
+        ))}
+      </div>
+
+      {DIVIDER}
+
+      {/* Copyright */}
+      <div className="px-[24px] pt-[20px] pb-[28px]">
+        <p className="text-[#71717b] text-[11px]">
+          Copyright &copy; Grenada Airports Authority {new Date().getFullYear()}
+          , Grenada Meteorological Service
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/apps/web/spicewx/src/components/forecasts/friday-may-22.tsx
+++ b/apps/web/spicewx/src/components/forecasts/friday-may-22.tsx
@@ -1,5 +1,4 @@
 import { WeatherConditions } from "@/components/weather-conditions";
-import { WARNINGS } from "@/lib/forecast-data";
 
 const CONDITIONS = [
   { label: "Sunrise", value: "5:42 a.m." },
@@ -10,15 +9,8 @@ const CONDITIONS = [
   { label: "Wind Direction", value: "E to SE" },
   { label: "Sea State", value: "Moderate" },
   { label: "Wave Height", value: "4–6 ft" },
-  { label: "Warning", value: "None" },
 ];
 
 export function FridayMay22Forecast() {
-  return (
-    <WeatherConditions
-      conditions={CONDITIONS}
-      title="Key Conditions — Fri 22 May"
-      warnings={WARNINGS}
-    />
-  );
+  return <WeatherConditions conditions={CONDITIONS} />;
 }

--- a/apps/web/spicewx/src/components/forecasts/friday-may-22.tsx
+++ b/apps/web/spicewx/src/components/forecasts/friday-may-22.tsx
@@ -1,0 +1,24 @@
+import { WeatherConditions } from "@/components/weather-conditions";
+import { WARNINGS } from "@/lib/forecast-data";
+
+const CONDITIONS = [
+  { label: "Sunrise", value: "5:42 a.m." },
+  { label: "Sunset", value: "6:25 p.m." },
+  { label: "Max Temp", value: "31.0°C" },
+  { label: "Min Temp", value: "26.0°C" },
+  { label: "Wind Speed", value: "15–25 mph" },
+  { label: "Wind Direction", value: "E to SE" },
+  { label: "Sea State", value: "Moderate" },
+  { label: "Wave Height", value: "4–6 ft" },
+  { label: "Warning", value: "None" },
+];
+
+export function FridayMay22Forecast() {
+  return (
+    <WeatherConditions
+      conditions={CONDITIONS}
+      title="Key Conditions — Fri 22 May"
+      warnings={WARNINGS}
+    />
+  );
+}

--- a/apps/web/spicewx/src/components/forecasts/thursday-may-21.tsx
+++ b/apps/web/spicewx/src/components/forecasts/thursday-may-21.tsx
@@ -1,5 +1,4 @@
 import { WeatherConditions } from "@/components/weather-conditions";
-import { WARNINGS } from "@/lib/forecast-data";
 
 const CONDITIONS = [
   { label: "Sunrise", value: "5:42 a.m." },
@@ -10,15 +9,8 @@ const CONDITIONS = [
   { label: "Wind Direction", value: "E to SE" },
   { label: "Sea State", value: "Moderate" },
   { label: "Wave Height", value: "4–6 ft" },
-  { label: "Warning", value: "None" },
 ];
 
 export function ThursdayMay21Forecast() {
-  return (
-    <WeatherConditions
-      conditions={CONDITIONS}
-      title="Key Conditions — Thu 21 May"
-      warnings={WARNINGS}
-    />
-  );
+  return <WeatherConditions conditions={CONDITIONS} />;
 }

--- a/apps/web/spicewx/src/components/forecasts/thursday-may-21.tsx
+++ b/apps/web/spicewx/src/components/forecasts/thursday-may-21.tsx
@@ -1,0 +1,24 @@
+import { WeatherConditions } from "@/components/weather-conditions";
+import { WARNINGS } from "@/lib/forecast-data";
+
+const CONDITIONS = [
+  { label: "Sunrise", value: "5:42 a.m." },
+  { label: "Sunset", value: "6:25 p.m." },
+  { label: "Max Temp", value: "31.0°C" },
+  { label: "Min Temp", value: "26.0°C" },
+  { label: "Wind Speed", value: "15–25 mph" },
+  { label: "Wind Direction", value: "E to SE" },
+  { label: "Sea State", value: "Moderate" },
+  { label: "Wave Height", value: "4–6 ft" },
+  { label: "Warning", value: "None" },
+];
+
+export function ThursdayMay21Forecast() {
+  return (
+    <WeatherConditions
+      conditions={CONDITIONS}
+      title="Key Conditions — Thu 21 May"
+      warnings={WARNINGS}
+    />
+  );
+}

--- a/apps/web/spicewx/src/components/forecasts/tuesday-may-19.tsx
+++ b/apps/web/spicewx/src/components/forecasts/tuesday-may-19.tsx
@@ -1,5 +1,4 @@
 import { WeatherConditions } from "@/components/weather-conditions";
-import { WARNINGS } from "@/lib/forecast-data";
 
 const CONDITIONS = [
   { label: "Sunrise", value: "5:42 a.m." },
@@ -12,15 +11,8 @@ const CONDITIONS = [
   { label: "Wave Height", value: "6–8 ft" },
   { label: "Low Tide", value: "10:30 a.m." },
   { label: "High Tide", value: "4:45 p.m." },
-  { label: "Warning", value: "None" },
 ];
 
 export function TuesdayMay19Forecast() {
-  return (
-    <WeatherConditions
-      conditions={CONDITIONS}
-      title="Key Conditions — Tue 19 May"
-      warnings={WARNINGS}
-    />
-  );
+  return <WeatherConditions conditions={CONDITIONS} />;
 }

--- a/apps/web/spicewx/src/components/forecasts/tuesday-may-19.tsx
+++ b/apps/web/spicewx/src/components/forecasts/tuesday-may-19.tsx
@@ -1,0 +1,26 @@
+import { WeatherConditions } from "@/components/weather-conditions";
+import { WARNINGS } from "@/lib/forecast-data";
+
+const CONDITIONS = [
+  { label: "Sunrise", value: "5:42 a.m." },
+  { label: "Sunset", value: "6:25 p.m." },
+  { label: "Max Temp", value: "31.0°C" },
+  { label: "Min Temp", value: "26.0°C" },
+  { label: "Wind Speed", value: "15–25 mph" },
+  { label: "Wind Direction", value: "E to SE" },
+  { label: "Sea State", value: "Moderate to slightly rough" },
+  { label: "Wave Height", value: "6–8 ft" },
+  { label: "Low Tide", value: "10:30 a.m." },
+  { label: "High Tide", value: "4:45 p.m." },
+  { label: "Warning", value: "None" },
+];
+
+export function TuesdayMay19Forecast() {
+  return (
+    <WeatherConditions
+      conditions={CONDITIONS}
+      title="Key Conditions — Tue 19 May"
+      warnings={WARNINGS}
+    />
+  );
+}

--- a/apps/web/spicewx/src/components/forecasts/wednesday-may-20.tsx
+++ b/apps/web/spicewx/src/components/forecasts/wednesday-may-20.tsx
@@ -1,0 +1,24 @@
+import { WeatherConditions } from "@/components/weather-conditions";
+import { WARNINGS } from "@/lib/forecast-data";
+
+const CONDITIONS = [
+  { label: "Sunrise", value: "5:42 a.m." },
+  { label: "Sunset", value: "6:25 p.m." },
+  { label: "Max Temp", value: "31.0°C" },
+  { label: "Min Temp", value: "26.0°C" },
+  { label: "Wind Speed", value: "15–25 mph" },
+  { label: "Wind Direction", value: "E to SE" },
+  { label: "Sea State", value: "Moderate" },
+  { label: "Wave Height", value: "4–6 ft" },
+  { label: "Warning", value: "None" },
+];
+
+export function WednesdayMay20Forecast() {
+  return (
+    <WeatherConditions
+      conditions={CONDITIONS}
+      title="Key Conditions — Wed 20 May"
+      warnings={WARNINGS}
+    />
+  );
+}

--- a/apps/web/spicewx/src/components/forecasts/wednesday-may-20.tsx
+++ b/apps/web/spicewx/src/components/forecasts/wednesday-may-20.tsx
@@ -1,5 +1,4 @@
 import { WeatherConditions } from "@/components/weather-conditions";
-import { WARNINGS } from "@/lib/forecast-data";
 
 const CONDITIONS = [
   { label: "Sunrise", value: "5:42 a.m." },
@@ -10,15 +9,8 @@ const CONDITIONS = [
   { label: "Wind Direction", value: "E to SE" },
   { label: "Sea State", value: "Moderate" },
   { label: "Wave Height", value: "4–6 ft" },
-  { label: "Warning", value: "None" },
 ];
 
 export function WednesdayMay20Forecast() {
-  return (
-    <WeatherConditions
-      conditions={CONDITIONS}
-      title="Key Conditions — Wed 20 May"
-      warnings={WARNINGS}
-    />
-  );
+  return <WeatherConditions conditions={CONDITIONS} />;
 }

--- a/apps/web/spicewx/src/components/gms-news.tsx
+++ b/apps/web/spicewx/src/components/gms-news.tsx
@@ -3,7 +3,6 @@ import Image from "next/image";
 const posts = [
   {
     id: 1,
-    author: "GMS Grenada",
     time: "Yesterday at 10:41 am",
     paragraphs: [
       "We're halfway through May and conditions across Grenada remain partly cloudy with isolated afternoon showers.",
@@ -14,7 +13,6 @@ const posts = [
   },
   {
     id: 2,
-    author: "GMS Grenada",
     time: "May 15 at 10:38 pm",
     paragraphs: [
       "What will the weather look like after 17 May? The week begins with high pressure building from the north bringing drier and warmer conditions.",
@@ -25,7 +23,6 @@ const posts = [
   },
   {
     id: 3,
-    author: "GMS Grenada",
     time: "May 15 at 9:08 pm",
     paragraphs: [
       "The changing sea state makes coastal conditions difficult to predict for this weekend. We'll keep you updated:",
@@ -36,7 +33,6 @@ const posts = [
   },
   {
     id: 4,
-    author: "GMS Grenada",
     time: "May 15 at 8:11 pm",
     paragraphs: [
       "Carriacou and Petite Martinique could experience some of the strongest winds this weekend.",
@@ -49,40 +45,42 @@ const posts = [
 
 function PostCard({ post }: { post: (typeof posts)[number] }) {
   return (
-    <div className="flex flex-col rounded-xl border border-gm-border bg-white p-4 shadow-sm">
-      <div className="mb-3 flex items-start justify-between gap-2">
-        <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gm-sky font-bold text-sm text-white">
+    <div className="flex flex-col gap-[12px] rounded-[12px] border border-[#d0d5dd] bg-white p-[17px] shadow-[0px_1px_3px_0px_rgba(0,0,0,0.1),0px_1px_2px_-1px_rgba(0,0,0,0.1)]">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-[12px]">
+          <div className="flex size-[40px] shrink-0 items-center justify-center rounded-full bg-[#39a5f5] font-bold text-[14px] text-white">
             G
           </div>
-          <div>
-            <p className="font-semibold text-gm-navy text-sm">{post.author}</p>
-            <p className="text-gray-400 text-xs">{post.time}</p>
+          <div className="flex flex-col">
+            <p className="font-semibold text-[#150068] text-[13px] leading-[18px]">
+              GMS
+            </p>
+            <p className="text-[#99a1af] text-[11px] leading-[16px]">
+              {post.time}
+            </p>
           </div>
         </div>
-        <button
-          className="shrink-0 text-gray-400 hover:text-gray-600"
-          type="button"
-        >
-          •••
-        </button>
+        <p className="text-[#99a1af] text-[16px] leading-[24px]">•••</p>
       </div>
 
-      <div className="flex flex-col gap-2">
+      {/* Body */}
+      <div className="flex flex-col gap-[8px]">
         {post.paragraphs.map((p) => (
-          <p className="text-gray-700 text-sm leading-relaxed" key={p}>
+          <p className="text-[#364153] text-[13px] leading-[20px]" key={p}>
             {p}
           </p>
         ))}
       </div>
 
-      <div className="mt-3 overflow-hidden rounded-lg bg-gray-100">
+      {/* Image */}
+      <div className="overflow-hidden rounded-[8px] bg-[#f3f4f6]">
         <Image
           alt=""
-          className="h-44 w-full object-cover"
-          height={176}
+          className="h-[200px] w-full object-cover"
+          height={200}
           src={post.image}
-          width={400}
+          width={280}
         />
       </div>
     </div>
@@ -92,22 +90,21 @@ function PostCard({ post }: { post: (typeof posts)[number] }) {
 export function GmsNews() {
   return (
     <section className="mb-4">
-      <div className="flex items-center justify-between px-4 lg:px-0">
-        <h2 className="font-bold text-gm-navy text-lg lg:text-xl">
+      <div className="mb-[10px] flex items-center justify-between">
+        <h2 className="font-bold text-[#150068] text-[18px] leading-[24px]">
           Latest from us
         </h2>
         <a
-          className="font-medium text-gm-blue text-sm hover:underline"
+          className="font-medium text-[#2478f2] text-[14px] leading-[20px]"
           href="/news"
         >
           See more
         </a>
       </div>
 
-      {/* Mobile: horizontal scroll carousel → Desktop: 4-col grid */}
-      <div className="flex gap-3 overflow-x-auto [scrollbar-width:none] lg:grid lg:grid-cols-4 lg:gap-4 lg:overflow-visible lg:px-0 lg:pb-0">
+      <div className="flex gap-[12px] overflow-x-auto [scrollbar-width:none] lg:grid lg:grid-cols-4 lg:overflow-visible">
         {posts.map((post) => (
-          <div className="w-[85vw] shrink-0 lg:w-auto" key={post.id}>
+          <div className="w-75 shrink-0 lg:w-auto" key={post.id}>
             <PostCard post={post} />
           </div>
         ))}

--- a/apps/web/spicewx/src/components/header.tsx
+++ b/apps/web/spicewx/src/components/header.tsx
@@ -14,9 +14,10 @@ import Image from "next/image";
 import { cn } from "@/lib/utils";
 
 const navigation = [
-  { name: "Weather and Climate", href: "/forecasts", current: true },
-  { name: "Products & Services", href: "/warnings", current: false },
-  { name: "Resources", href: "/marine", current: false },
+  { name: "Weather and Climate", href: "/weather", current: true },
+  { name: "Products & Services", href: "/products", current: false },
+  { name: "Resources", href: "/resources", current: false },
+  { name: "About Us", href: "/about", current: false },
 ];
 
 const userNavigation = [
@@ -34,11 +35,11 @@ export function Header() {
             <div className="flex shrink-0 items-center">
               {/* Mobile: submark */}
               <Image
-                alt="GrenMet"
-                className="block sm:hidden"
-                height={50}
-                src="/gmslogos/logo-submark-navy-blue.png"
-                width={50}
+                alt="Grenada Meteorological Service"
+                className="sm:hidden block"
+                height={40}
+                src="/gmslogos/logo-primary-navy.png"
+                width={180}
               />
               {/* Desktop: full primary logo */}
               <Image
@@ -57,7 +58,7 @@ export function Header() {
                     item.current
                       ? "border-gm-blue text-gm-navy"
                       : "border-transparent text-muted-foreground hover:border-gm-border hover:text-gm-navy",
-                    "inline-flex items-center border-b-2 px-1 pt-1 font-medium text-sm transition-colors"
+                    "inline-flex items-center border-b-2 px-1 pt-1 font-medium text-sm transition-colors",
                   )}
                   href={item.href}
                   key={item.name}
@@ -128,7 +129,7 @@ export function Header() {
                 item.current
                   ? "border-gm-blue bg-gm-surface text-gm-navy"
                   : "border-transparent text-muted-foreground hover:border-gm-border hover:bg-gm-surface hover:text-gm-navy",
-                "block border-l-4 py-2 pr-4 pl-3 font-medium text-base transition-colors"
+                "block border-l-4 py-2 pr-4 pl-3 font-medium text-base transition-colors",
               )}
               href={item.href}
               key={item.name}

--- a/apps/web/spicewx/src/components/header.tsx
+++ b/apps/web/spicewx/src/components/header.tsx
@@ -1,144 +1,34 @@
 "use client";
 
-import {
-  Disclosure,
-  DisclosureButton,
-  DisclosurePanel,
-  Menu,
-  MenuButton,
-  MenuItem,
-  MenuItems,
-} from "@headlessui/react";
-import { Bars3Icon, BellIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { Bars2Icon } from "@heroicons/react/24/outline";
 import Image from "next/image";
-import { cn } from "@/lib/utils";
-
-const navigation = [
-  { name: "Weather and Climate", href: "/weather", current: true },
-  { name: "Products & Services", href: "/products", current: false },
-  { name: "Resources", href: "/resources", current: false },
-  { name: "About Us", href: "/about", current: false },
-];
-
-const userNavigation = [
-  { name: "Your profile", href: "/profile" },
-  { name: "Settings", href: "/settings" },
-  { name: "Sign out", href: "/sign-out" },
-];
+import { useState } from "react";
+import { NavDrawer } from "@/components/nav-drawer";
 
 export function Header() {
+  const [navOpen, setNavOpen] = useState(false);
+
   return (
-    <Disclosure as="nav" className="mb-4 border-gm-border border-b bg-white">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="flex h-16 justify-between">
-          <div className="flex">
-            <div className="flex shrink-0 items-center">
-              {/* Mobile: submark */}
-              <Image
-                alt="Grenada Meteorological Service"
-                className="sm:hidden block"
-                height={40}
-                src="/gmslogos/logo-primary-navy.png"
-                width={180}
-              />
-              {/* Desktop: full primary logo */}
-              <Image
-                alt="Grenada Meteorological Service"
-                className="hidden sm:block"
-                height={40}
-                src="/gmslogos/logo-primary-navy.png"
-                width={180}
-              />
-            </div>
-            <div className="hidden sm:-my-px sm:ml-8 sm:flex sm:space-x-6">
-              {navigation.map((item) => (
-                <a
-                  aria-current={item.current ? "page" : undefined}
-                  className={cn(
-                    item.current
-                      ? "border-gm-blue text-gm-navy"
-                      : "border-transparent text-muted-foreground hover:border-gm-border hover:text-gm-navy",
-                    "inline-flex items-center border-b-2 px-1 pt-1 font-medium text-sm transition-colors",
-                  )}
-                  href={item.href}
-                  key={item.name}
-                >
-                  {item.name}
-                </a>
-              ))}
-            </div>
-          </div>
+    <>
+      <header className="sticky top-0 z-40 flex h-[72px] items-center justify-between border-[#d0d5dd] border-b bg-white pr-[20px] pl-[24px]">
+        <Image
+          alt="Grenada Meteorological Service"
+          height={36}
+          priority
+          src="/gmslogos/logo-primary-navy.png"
+          width={150}
+        />
+        <button
+          aria-label="Open navigation"
+          className="flex size-[44px] items-center justify-center"
+          onClick={() => setNavOpen(true)}
+          type="button"
+        >
+          <Bars2Icon className="size-[24px] text-gray-900" />
+        </button>
+      </header>
 
-          <div className="hidden sm:ml-6 sm:flex sm:items-center">
-            <button
-              className="relative rounded-full p-1 text-muted-foreground transition-colors hover:text-gm-navy focus:outline-2 focus:outline-gm-sky focus:outline-offset-2"
-              type="button"
-            >
-              <span className="absolute -inset-1.5" />
-              <span className="sr-only">View notifications</span>
-              <BellIcon aria-hidden="true" className="size-6" />
-            </button>
-
-            <Menu as="div" className="relative ml-3">
-              <MenuButton className="relative flex h-8 w-8 items-center justify-center rounded-full bg-gm-navy font-bold text-sm text-white focus-visible:outline-2 focus-visible:outline-gm-sky focus-visible:outline-offset-2">
-                <span className="absolute -inset-1.5" />
-                <span className="sr-only">Open user menu</span>U
-              </MenuButton>
-              <MenuItems
-                className="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg outline outline-black/5 transition data-closed:scale-95 data-closed:opacity-0 data-enter:duration-200 data-leave:duration-75 data-enter:ease-out data-leave:ease-in"
-                transition
-              >
-                {userNavigation.map((item) => (
-                  <MenuItem key={item.name}>
-                    <a
-                      className="block px-4 py-2 text-gray-700 text-sm data-focus:bg-gm-surface data-focus:outline-hidden"
-                      href={item.href}
-                    >
-                      {item.name}
-                    </a>
-                  </MenuItem>
-                ))}
-              </MenuItems>
-            </Menu>
-          </div>
-
-          <div className="-mr-2 flex items-center sm:hidden">
-            <DisclosureButton className="group relative inline-flex items-center justify-center rounded-md p-2 text-muted-foreground transition-colors hover:bg-gm-surface hover:text-gm-navy focus:outline-2 focus:outline-gm-sky focus:outline-offset-2">
-              <span className="absolute -inset-0.5" />
-              <span className="sr-only">Open main menu</span>
-              <Bars3Icon
-                aria-hidden="true"
-                className="block size-6 group-data-open:hidden"
-              />
-              <XMarkIcon
-                aria-hidden="true"
-                className="hidden size-6 group-data-open:block"
-              />
-            </DisclosureButton>
-          </div>
-        </div>
-      </div>
-
-      <DisclosurePanel className="border-gm-border border-t bg-white sm:hidden">
-        <div className="space-y-1 pt-2 pb-3">
-          {navigation.map((item) => (
-            <DisclosureButton
-              aria-current={item.current ? "page" : undefined}
-              as="a"
-              className={cn(
-                item.current
-                  ? "border-gm-blue bg-gm-surface text-gm-navy"
-                  : "border-transparent text-muted-foreground hover:border-gm-border hover:bg-gm-surface hover:text-gm-navy",
-                "block border-l-4 py-2 pr-4 pl-3 font-medium text-base transition-colors",
-              )}
-              href={item.href}
-              key={item.name}
-            >
-              {item.name}
-            </DisclosureButton>
-          ))}
-        </div>
-      </DisclosurePanel>
-    </Disclosure>
+      <NavDrawer onClose={() => setNavOpen(false)} open={navOpen} />
+    </>
   );
 }

--- a/apps/web/spicewx/src/components/nav-drawer.tsx
+++ b/apps/web/spicewx/src/components/nav-drawer.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import {
+  Disclosure,
+  DisclosureButton,
+  DisclosurePanel,
+} from "@headlessui/react";
+import { ChevronDownIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import Image from "next/image";
+import { useEffect } from "react";
+import { cn } from "@/lib/utils";
+
+const NAV_SECTIONS = [
+  {
+    label: "Warnings",
+    links: [
+      { name: "Current alerts", href: "/warnings" },
+      { name: "Weather Advisories", href: "/warnings/advisories" },
+      { name: "Impact-Based Warnings", href: "/warnings/impact" },
+      { name: "Tropical Cyclone Information", href: "/warnings/cyclone" },
+      { name: "Marine Warnings", href: "/warnings/marine" },
+      { name: "Warning Levels Explained", href: "/warnings/levels" },
+    ],
+  },
+  {
+    label: "Forecasts",
+    links: [
+      { name: "Today's Forecast", href: "/" },
+      { name: "3-Day Forecast", href: "/forecasts/3-day" },
+      { name: "7-Day Outlook", href: "/forecasts/7-day" },
+      { name: "Weather Synopsis", href: "/forecasts/synopsis" },
+      { name: "Radar", href: "/forecasts/radar" },
+      { name: "Satellite", href: "/forecasts/satellite" },
+      { name: "Current Conditions", href: "/forecasts/conditions" },
+    ],
+  },
+  {
+    label: "Marine",
+    links: [
+      { name: "Marine Forecast", href: "/marine/forecast" },
+      { name: "Coastal Waters Forecast", href: "/marine/coastal" },
+      { name: "Sea Conditions", href: "/marine/sea-conditions" },
+      { name: "Wave / Swell Forecast", href: "/marine/wave-swell" },
+      { name: "Tide Information", href: "/marine/tides" },
+      { name: "Small Craft Advisories", href: "/marine/small-craft" },
+      { name: "Marine Safety", href: "/marine/safety" },
+    ],
+  },
+  {
+    label: "Sectors",
+    links: [
+      { name: "Aviation", href: "/sectors/aviation" },
+      { name: "Disaster Management", href: "/sectors/disaster-management" },
+      { name: "Agriculture", href: "/sectors/agriculture" },
+      { name: "Tourism & Events", href: "/sectors/tourism" },
+      { name: "Construction", href: "/sectors/construction" },
+      { name: "Education", href: "/sectors/education" },
+      { name: "Health", href: "/sectors/health" },
+    ],
+  },
+  {
+    label: "Climate & Data",
+    links: [
+      { name: "Monthly Climate Summary", href: "/climate/monthly" },
+      { name: "Rainfall Data", href: "/climate/rainfall" },
+      { name: "Temperature Data", href: "/climate/temperature" },
+      { name: "Historical Weather Data", href: "/climate/historical" },
+      { name: "Climate Normals", href: "/climate/normals" },
+      { name: "Seasonal Outlook", href: "/climate/seasonal" },
+      { name: "Drought Monitoring", href: "/climate/drought" },
+      { name: "Data Request Form", href: "/climate/data-request" },
+      { name: "Publications", href: "/climate/publications" },
+    ],
+  },
+  {
+    label: "Resources",
+    links: [
+      { name: "Weather Glossary", href: "/resources/glossary" },
+      { name: "Understanding Warnings", href: "/resources/warnings-guide" },
+      { name: "Hurricane Preparedness", href: "/resources/hurricane" },
+      { name: "Flood Preparedness", href: "/resources/flood" },
+      { name: "Marine Safety", href: "/resources/marine-safety" },
+      { name: "School Resources", href: "/resources/school" },
+      { name: "FAQs", href: "/resources/faqs" },
+      { name: "Downloads", href: "/resources/downloads" },
+    ],
+  },
+  {
+    label: "About",
+    links: [],
+  },
+];
+
+interface NavDrawerProps {
+  onClose: () => void;
+  open: boolean;
+}
+
+export function NavDrawer({ open, onClose }: NavDrawerProps) {
+  useEffect(() => {
+    document.body.style.overflow = open ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col bg-white">
+      {/* Header */}
+      <div className="flex h-[72px] shrink-0 items-center justify-between border-[#d0d5dd] border-b pr-[20px] pl-[24px]">
+        <Image
+          alt="Grenada Meteorological Service"
+          height={36}
+          priority
+          src="/gmslogos/logo-primary-navy.png"
+          width={150}
+        />
+        <button
+          aria-label="Close navigation"
+          className="flex size-[44px] items-center justify-center"
+          onClick={onClose}
+          type="button"
+        >
+          <XMarkIcon className="size-[24px] text-gray-900" />
+        </button>
+      </div>
+
+      {/* Brand accent line */}
+      <div className="flex h-[4px] w-full shrink-0">
+        <div className="h-full flex-[55] bg-gm-blue" />
+        <div className="h-full flex-[25] bg-gm-sky" />
+        <div className="h-full flex-[20] bg-gm-sun" />
+      </div>
+
+      {/* Nav body */}
+      <nav className="flex-1 overflow-y-auto pb-[36px]">
+        {NAV_SECTIONS.map((section, i) => (
+          <Disclosure key={section.label}>
+            {({ open: sectionOpen }) => (
+              <>
+                <DisclosureButton
+                  className={cn(
+                    "flex h-[72px] w-full items-center justify-between pr-[20px] pl-[24px]",
+                    i > 0 && "border-[#d0d5dd] border-t"
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "text-[30px] leading-[36px]",
+                      sectionOpen
+                        ? "font-semibold text-gm-navy"
+                        : "font-normal text-[#111827]"
+                    )}
+                  >
+                    {section.label}
+                  </span>
+                  <div className="flex size-[44px] items-center justify-center">
+                    <ChevronDownIcon
+                      className={cn(
+                        "size-[24px] transition-transform duration-150",
+                        sectionOpen
+                          ? "rotate-180 text-gm-navy"
+                          : "text-gray-400"
+                      )}
+                    />
+                  </div>
+                </DisclosureButton>
+
+                {section.links.length > 0 && (
+                  <DisclosurePanel>
+                    {section.links.map((link) => (
+                      <a
+                        className="flex h-[44px] items-center pr-[20px] pl-[42px] text-[#111827] text-[20px] leading-[28px] hover:text-gm-navy"
+                        href={link.href}
+                        key={link.name}
+                        onClick={onClose}
+                      >
+                        {link.name}
+                      </a>
+                    ))}
+                  </DisclosurePanel>
+                )}
+              </>
+            )}
+          </Disclosure>
+        ))}
+      </nav>
+    </div>
+  );
+}

--- a/apps/web/spicewx/src/components/news.tsx
+++ b/apps/web/spicewx/src/components/news.tsx
@@ -5,8 +5,8 @@ const posts = [
     id: 1,
     title:
       "Tropical wave brings heavy showers to southern parishes this weekend",
-    description:
-      "Are you planning outdoor activities this weekend? Residents in St. George's and St. David's should prepare for periods of heavy rain and gusty winds.",
+    summary:
+      "Wave heights of 6–9 ft are expected through the weekend. The GMS urges mariners to exercise extreme caution and monitor updated bulletins.",
     imageUrl:
       "https://images.unsplash.com/photo-1561553543-e4c7b608b98d?auto=format&fit=crop&w=800&q=80",
     published: "Friday, May 16",
@@ -15,7 +15,7 @@ const posts = [
   {
     id: 2,
     title: "Sea state remains rough — small craft advisory in effect",
-    description:
+    summary:
       "Wave heights of 6–9 ft are expected through the weekend. The GMS urges mariners to exercise extreme caution and monitor updated bulletins.",
     imageUrl:
       "https://images.unsplash.com/photo-1505118380757-91f5f5632de0?auto=format&fit=crop&w=800&q=80",
@@ -25,7 +25,7 @@ const posts = [
   {
     id: 3,
     title: "Dry season outlook: warmer and drier conditions ahead for Grenada",
-    description:
+    summary:
       "The seasonal forecast indicates below-normal rainfall and above-normal temperatures for the coming months across the tri-island state.",
     imageUrl:
       "https://images.unsplash.com/photo-1504370805625-d32c54b16100?auto=format&fit=crop&w=800&q=80",
@@ -34,39 +34,54 @@ const posts = [
   },
 ];
 
+function NewsCard({ post }: { post: (typeof posts)[number] }) {
+  return (
+    <a
+      className="flex flex-col overflow-clip rounded-[4px] border border-[#d0d5dd] bg-white p-px shadow-[0px_1px_3px_0px_rgba(0,0,0,0.1),0px_1px_2px_-1px_rgba(0,0,0,0.1)]"
+      href={post.href}
+    >
+      <div className="relative h-[254px] w-full shrink-0 overflow-clip bg-[#f3f4f6]">
+        <Image
+          alt=""
+          className="object-cover"
+          fill
+          sizes="100vw"
+          src={post.imageUrl}
+        />
+      </div>
+      <div className="flex flex-col gap-[8px] p-[16px]">
+        <p className="font-bold text-[#150068] text-[15px] leading-[21px]">
+          {post.title}
+        </p>
+        <p className="text-[#4a5565] text-[13px] leading-[20px]">
+          {post.summary}
+        </p>
+        <p className="text-[#2478f2] text-[11px] leading-[16px]">
+          Published {post.published}
+        </p>
+      </div>
+    </a>
+  );
+}
+
 export function News() {
   return (
-    <section className="mb-4">
-      <h2 className="mb-4 font-bold text-gm-navy text-xl">Weather news</h2>
+    <section className="mb-4 flex flex-col gap-[16px]">
+      <div className="flex h-[28px] items-center justify-between">
+        <p className="font-bold text-[#150068] text-[18px] leading-[24px]">
+          Weather news
+        </p>
+        <a
+          className="font-medium text-[#2478f2] text-[14px] leading-[20px]"
+          href="/news"
+        >
+          See more
+        </a>
+      </div>
 
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+      <div className="flex flex-col gap-[16px] lg:grid lg:grid-cols-3">
         {posts.map((post) => (
-          <a
-            className="group flex flex-col overflow-hidden rounded border border-gm-border bg-white shadow-sm transition hover:shadow-md"
-            href={post.href}
-            key={post.id}
-          >
-            <div className="relative aspect-video w-full overflow-hidden bg-gray-100">
-              <Image
-                alt=""
-                className="h-full w-full object-cover transition group-hover:scale-105"
-                fill
-                sizes="(min-width: 1024px) 33vw, 100vw"
-                src={post.imageUrl}
-              />
-            </div>
-            <div className="flex flex-1 flex-col gap-2 p-4">
-              <h3 className="font-bold text-base text-gm-navy leading-snug group-hover:text-gm-blue">
-                {post.title}
-              </h3>
-              <p className="text-gray-600 text-sm leading-relaxed lg:line-clamp-2">
-                {post.description}
-              </p>
-              <p className="pt-1 text-gm-blue text-xs lg:mt-auto lg:pt-2">
-                Published {post.published}
-              </p>
-            </div>
-          </a>
+          <NewsCard key={post.id} post={post} />
         ))}
       </div>
     </section>

--- a/apps/web/spicewx/src/components/page-header.tsx
+++ b/apps/web/spicewx/src/components/page-header.tsx
@@ -7,7 +7,7 @@ export function PageHeader({ title, description }: PageHeaderProps) {
   return (
     <div className="mx-4 mb-4">
       <div className="mx-auto max-w-7xl lg:px-8 lg:py-6">
-        <h1 className="font-bold text-2xl text-gm-navy sm:text-3xl">{title}</h1>
+        <h1 className="font-bold text-3xl text-gm-navy sm:text-3xl">{title}</h1>
         {description && (
           <p className="mt-1 text-muted-foreground text-sm">{description}</p>
         )}

--- a/apps/web/spicewx/src/components/weather-conditions.tsx
+++ b/apps/web/spicewx/src/components/weather-conditions.tsx
@@ -1,73 +1,65 @@
-import { AlertTriangle, ArrowRight } from "lucide-react";
-import type { Condition, Warning } from "@/lib/forecast-data";
-import { cn } from "@/lib/utils";
+import type { LucideIcon } from "lucide-react";
+import {
+  ArrowDownToLine,
+  ArrowUpToLine,
+  Navigation,
+  Sunrise,
+  Sunset,
+  Thermometer,
+  Umbrella,
+  Waves,
+  Wind,
+} from "lucide-react";
+import type { Condition } from "@/lib/forecast-data";
+
+const ICON_MAP: Record<string, LucideIcon> = {
+  "Max Temp": Thermometer,
+  "Min Temp": Thermometer,
+  "Wind Speed": Wind,
+  "Wind Direction": Navigation,
+  "Rain Chance": Umbrella,
+  "Sea State": Waves,
+  "Wave Height": Waves,
+  "Low Tide": ArrowDownToLine,
+  "High Tide": ArrowUpToLine,
+  Sunrise,
+  Sunset,
+  "Sunrise Today": Sunrise,
+  "Sunrise Tomorrow": Sunrise,
+  "Sunrise Sunday": Sunrise,
+  "Sunset Today": Sunset,
+};
 
 interface WeatherConditionsProps {
   conditions: Condition[];
-  title: string;
-  warnings: Warning[];
 }
 
-export function WeatherConditions({
-  title,
-  conditions,
-  warnings,
-}: WeatherConditionsProps) {
+export function WeatherConditions({ conditions }: WeatherConditionsProps) {
   return (
-    <div className="flex flex-1 flex-col lg:flex-row">
-      <div className="flex-1 p-4 lg:p-5">
-        <h2 className="mb-4 font-bold text-gm-blue text-sm uppercase tracking-widest">
-          {title}
-        </h2>
-        <div className="grid grid-cols-2 gap-x-4 gap-y-5 lg:grid-cols-3 lg:gap-x-6">
-          {conditions.map((item) => (
-            <div className="flex items-center gap-3" key={item.label}>
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gm-surface text-gm-blue text-xs">
-                icon
-              </div>
-              <div>
-                <p className="font-bold text-gm-navy text-sm">{item.value}</p>
-                <p className="text-gray-500 text-xs">{item.label}</p>
-              </div>
+    <div className="grid grid-cols-2 gap-2 bg-white pt-2 pb-1">
+      {conditions.map((item) => {
+        const Icon = ICON_MAP[item.label];
+        return (
+          <div
+            className="flex items-center gap-2 px-[10px] py-[8px]"
+            key={item.label}
+          >
+            <div className="flex size-[30px] shrink-0 items-center justify-center">
+              {Icon && (
+                <Icon className="h-5 w-5 text-gray-400" strokeWidth={1.5} />
+              )}
             </div>
-          ))}
-        </div>
-      </div>
-
-      <div className="hidden w-64 shrink-0 flex-col lg:flex">
-        <a
-          className="flex items-center justify-between bg-gm-risk-amber px-4 py-3 font-semibold text-gray-900 text-sm"
-          href="/warnings"
-        >
-          <span className="flex items-center gap-1.5">
-            <AlertTriangle className="h-4 w-4 shrink-0" />
-            Current warnings
-          </span>
-          <ArrowRight className="h-4 w-4 shrink-0" />
-        </a>
-        <div className="flex-1 divide-y divide-white/10 bg-gm-navy">
-          {warnings.map((w) => (
-            <div className="flex items-center gap-3 px-4 py-3" key={w.region}>
-              <span
-                className={cn(
-                  "w-4 shrink-0 font-bold text-sm tabular-nums",
-                  w.count > 0 ? "text-gm-risk-amber" : "text-white/30"
-                )}
-              >
-                {w.count}
-              </span>
-              <span
-                className={cn(
-                  "text-sm",
-                  w.count > 0 ? "text-white" : "text-white/50"
-                )}
-              >
-                {w.region}
-              </span>
+            <div className="flex min-w-0 flex-col gap-px">
+              <p className="font-semibold text-[14px] text-gray-900 leading-[16px]">
+                {item.value}
+              </p>
+              <p className="text-[#4b5563] text-[11px] leading-[13px]">
+                {item.label}
+              </p>
             </div>
-          ))}
-        </div>
-      </div>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/spicewx/src/components/weather-date-nav.tsx
+++ b/apps/web/spicewx/src/components/weather-date-nav.tsx
@@ -10,41 +10,31 @@ export function WeatherDateNav() {
   const days = getForecastDays();
 
   return (
-    <div className="flex border-gm-border border-b bg-white lg:flex-col lg:divide-y lg:divide-gm-border lg:border-gm-border lg:border-r lg:border-b-0">
+    <div className="flex h-[83px] bg-[#f3f4f6]">
       {days.map((day) => {
         const href = day.isToday ? "/" : `/${day.slug}`;
         const isActive = day.isToday ? pathname === "/" : pathname === href;
+
         return (
           <Link
             className={cn(
-              "flex flex-1 flex-col items-center justify-center gap-1 border-b-2 py-3 text-center transition-colors",
-              "lg:w-24 lg:flex-none lg:border-b-0 lg:border-l-4 lg:gap-1.5 lg:px-3",
+              "flex flex-1 flex-col items-center justify-center gap-[4px] text-center",
               isActive
-                ? "border-gm-blue text-gm-navy"
-                : "border-transparent text-gray-400 hover:text-gm-navy",
+                ? "border-[1.5px] border-gm-navy bg-white px-[1.5px] py-[7.5px] text-gm-navy"
+                : "bg-[#f3f4f6] py-[6px] text-gray-500"
             )}
             href={href}
             key={day.slug}
           >
-            {day.isToday ? (
-              <>
-                <span className="font-bold text-base leading-none lg:text-2xl">
-                  12:00 PM
-                </span>
-                <span className="font-bold text-base leading-none lg:text-2xl">
-                  {day.date}
-                </span>
-                <span className="text-xs tracking-wide">{day.month}</span>
-              </>
-            ) : (
-              <>
-                <span className="text-xs tracking-wide">{day.dayName}</span>
-                <span className="font-bold text-base leading-none lg:text-2xl">
-                  {day.date}
-                </span>
-                <span className="text-xs tracking-wide">{day.month}</span>
-              </>
-            )}
+            <span className="text-[10px] leading-[16px]">
+              {day.isToday ? "12:00 PM" : day.dayName}
+            </span>
+            <span className="font-bold text-[34px] leading-[36px]">
+              {day.date}
+            </span>
+            <span className="text-[13px] uppercase leading-[14px]">
+              {day.month}
+            </span>
           </Link>
         );
       })}

--- a/apps/web/spicewx/src/components/weather-date-nav.tsx
+++ b/apps/web/spicewx/src/components/weather-date-nav.tsx
@@ -17,21 +17,34 @@ export function WeatherDateNav() {
         return (
           <Link
             className={cn(
-              "flex flex-1 flex-col items-center justify-center border-b-2 py-3 text-center transition-colors",
-              "lg:w-16 lg:flex-none lg:border-b-0 lg:border-l-4 lg:px-2 lg:py-5",
+              "flex flex-1 flex-col items-center justify-center gap-1 border-b-2 py-3 text-center transition-colors",
+              "lg:w-24 lg:flex-none lg:border-b-0 lg:border-l-4 lg:gap-1.5 lg:px-3",
               isActive
                 ? "border-gm-blue text-gm-navy"
-                : "border-transparent text-gray-400 hover:text-gm-navy"
+                : "border-transparent text-gray-400 hover:text-gm-navy",
             )}
             href={href}
             key={day.slug}
           >
-            <span className="font-bold text-base leading-none lg:text-2xl">
-              {day.label ?? day.date}
-            </span>
-            <span className="mt-0.5 text-xs tracking-wide lg:mt-1">
-              {day.month}
-            </span>
+            {day.isToday ? (
+              <>
+                <span className="font-bold text-base leading-none lg:text-2xl">
+                  12:00 PM
+                </span>
+                <span className="font-bold text-base leading-none lg:text-2xl">
+                  {day.date}
+                </span>
+                <span className="text-xs tracking-wide">{day.month}</span>
+              </>
+            ) : (
+              <>
+                <span className="text-xs tracking-wide">{day.dayName}</span>
+                <span className="font-bold text-base leading-none lg:text-2xl">
+                  {day.date}
+                </span>
+                <span className="text-xs tracking-wide">{day.month}</span>
+              </>
+            )}
           </Link>
         );
       })}

--- a/apps/web/spicewx/src/lib/forecast-data.ts
+++ b/apps/web/spicewx/src/lib/forecast-data.ts
@@ -8,26 +8,22 @@ export interface Warning {
   region: string;
 }
 
-export const CONDITIONS: Condition[] = [
-  { label: "Max Temp", value: "31°C" },
-  { label: "Min Temp", value: "24°C" },
-  { label: "Wind Speed", value: "10–20 mph" },
-  { label: "Wind Direction", value: "N to E" },
-  { label: "Rain Chance", value: "40%" },
-  { label: "Sea State", value: "Moderate to rough" },
-  { label: "Wave Height", value: "6–9 ft" },
-  { label: "Swell", value: "NE to E" },
-  { label: "Low Tide", value: "12:30 pm" },
-  { label: "High Tide", value: "05:50 am" },
-  { label: "Sunset Today", value: "06:30 pm" },
-  { label: "Sunrise Tomorrow", value: "5:30 am" },
-];
-
 export const WARNINGS: Warning[] = [
-  { region: "Rain", count: 1 },
-  { region: "Thunderstorm", count: 1 },
+  { region: "Rain", count: 0 },
+  { region: "Thunderstorm", count: 0 },
   { region: "Wind", count: 0 },
   { region: "Marine", count: 0 },
   { region: "Dust", count: 0 },
-  { region: "Heat", count: 1 },
+  { region: "Heat", count: 0 },
+];
+
+export const TODAY_CONDITIONS: Condition[] = [
+  { label: "Tonight's Min", value: "26.0°C" },
+  { label: "Wind Speed", value: "14–24 mph" },
+  { label: "Wind Direction", value: "ENE to E" },
+  { label: "Sea State", value: "Moderate" },
+  { label: "Wave Height", value: "4–6 ft" },
+  { label: "Low Tide", value: "9:45 p.m." },
+  { label: "High Tide", value: "3:30 a.m." },
+  { label: "Warning", value: "None" },
 ];

--- a/apps/web/spicewx/src/lib/forecast-data.ts
+++ b/apps/web/spicewx/src/lib/forecast-data.ts
@@ -9,21 +9,25 @@ export interface Warning {
 }
 
 export const WARNINGS: Warning[] = [
-  { region: "Rain", count: 0 },
+  { region: "Tropical Cyclone", count: 0 },
+  { region: "Marine / Small Craft", count: 0 },
+  { region: "Flood / Heavy Rain", count: 0 },
   { region: "Thunderstorm", count: 0 },
   { region: "Wind", count: 0 },
-  { region: "Marine", count: 0 },
-  { region: "Dust", count: 0 },
   { region: "Heat", count: 0 },
+  { region: "Dust / Haze", count: 0 },
+  { region: "Coastal Hazard", count: 0 },
 ];
 
 export const TODAY_CONDITIONS: Condition[] = [
-  { label: "Tonight's Min", value: "26.0°C" },
-  { label: "Wind Speed", value: "14–24 mph" },
-  { label: "Wind Direction", value: "ENE to E" },
-  { label: "Sea State", value: "Moderate" },
-  { label: "Wave Height", value: "4–6 ft" },
-  { label: "Low Tide", value: "9:45 p.m." },
-  { label: "High Tide", value: "3:30 a.m." },
-  { label: "Warning", value: "None" },
+  { label: "Max Temp", value: "31°C" },
+  { label: "Wind Speed", value: "10–20 mph" },
+  { label: "Wind Direction", value: "NE to E" },
+  { label: "Rain Chance", value: "40%" },
+  { label: "Sea State", value: "Moderate to rough" },
+  { label: "Wave Height", value: "6–9 ft" },
+  { label: "Low Tide", value: "12:30 pm" },
+  { label: "High Tide", value: "4:45 pm" },
+  { label: "Sunset Today", value: "06:30 pm" },
+  { label: "Sunrise Tomorrow", value: "05:50 am" },
 ];

--- a/apps/web/spicewx/src/lib/forecast-days.ts
+++ b/apps/web/spicewx/src/lib/forecast-days.ts
@@ -1,7 +1,7 @@
 export interface ForecastDay {
   date: number;
+  dayName: string;
   isToday: boolean;
-  label: string | null;
   month: string;
   slug: string; // YYYY-MM-DD, used as the [date] URL segment
 }
@@ -13,8 +13,8 @@ export function getForecastDays(): ForecastDay[] {
     d.setDate(today.getDate() + i);
     return {
       date: d.getDate(),
-      month: d.toLocaleString("en-US", { month: "long" }),
-      label: i === 0 ? "Now" : null,
+      dayName: d.toLocaleString("en-US", { weekday: "short" }),
+      month: d.toLocaleString("en-US", { month: "short" }),
       slug: d.toISOString().slice(0, 10),
       isToday: i === 0,
     };


### PR DESCRIPTION
## Summary
- Rebuild header with correct 72px height, padding, and 2-bar menu icon
- Implement full-screen nav drawer with brand accent bar and accordion sections
- Update news cards (Weather News + Latest from Us) to match Figma specs
- Lock spicewx to light theme only via Tailwind v4 custom dark variant

## Test plan
- [ ] Header renders correctly at 390px mobile width
- [ ] Nav drawer opens/closes with scroll lock
- [ ] Brand accent line (blue/sky/sun) visible in open drawer
- [ ] All 7 nav sections expand/collapse with correct labels and links
- [ ] News cards match Figma dimensions and typography
- [ ] No dark mode triggered by system preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)