### PR TITLE
fix(wxwatch): use DATABASE_URL in prod compose

### DIFF
--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -103,7 +103,7 @@ services:
       db:
         condition: service_healthy
     environment:
-      DB_URL: ${WXWATCH_DB_URL}
+      DATABASE_URL: ${WXWATCH_DB_URL}
     networks:
       - grenmet
 
@@ -170,7 +170,7 @@ services:
       AUTH_API_V1_STR: /api/v1
       SESSION_COOKIE_NAME: ${SESSION_COOKIE_NAME}
       SESSION_COOKIE_DOMAIN: .barrels.gd
-      DB_URL: ${WXWATCH_DB_URL}
+      DATABASE_URL: ${WXWATCH_DB_URL}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.web-wxwatch.rule=Host(`wxwatch.barrels.gd`)"


### PR DESCRIPTION
## Summary
- Fixes 500 error on wxwatch.barrels.gd
- `docker-compose.prod.yml` was passing `DB_URL` to the wxwatch container but `env.ts` validates `DATABASE_URL` (required, no default)
- Verified working on staging (returns 307 redirect to signin as expected)

## Changes
- `infra/docker/docker-compose.prod.yml` — renamed `DB_URL` → `DATABASE_URL` for `wxwatch-migrate` and `web-wxwatch` services

🤖 Generated with [Claude Code](https://claude.com/claude-code)