### PR TITLE
fix(ci): add issues: write permission to labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
 
     steps:
       - name: Apply labels


### PR DESCRIPTION
Fixes labeler failing on every PR. Missing `issues: write` permission prevented label creation.