### PR TITLE
fix: auth Dockerfile email-templates, hurricaneplan build

### DIFF
--- a/apps/web/auth/Dockerfile
+++ b/apps/web/auth/Dockerfile
@@ -12,6 +12,7 @@ COPY packages/tsconfig/package.json packages/tsconfig/
 COPY packages/ui/package.json packages/ui/
 COPY packages/auth/package.json packages/auth/
 COPY packages/api-client/package.json packages/api-client/
+COPY packages/email-templates/package.json packages/email-templates/
 COPY apps/api/honoapi/package.json apps/api/honoapi/
 COPY apps/web/admin-gms/package.json apps/web/admin-gms/
 COPY apps/web/auth/package.json apps/web/auth/

--- a/apps/web/hurricaneplan/package.json
+++ b/apps/web/hurricaneplan/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "node scripts/generate-sections.mjs && next dev --turbopack --port 3003",
-    "build": "node scripts/generate-sections.mjs && next build --turbopack",
+    "build": "node scripts/generate-sections.mjs && next build",
     "start": "next start --port 3003",
     "lint": "biome lint .",
     "lint:fix": "biome lint --write .",


### PR DESCRIPTION
Fix web-auth Docker build (missing
  email-templates package) and hurricaneplan build (remove --turbopack from next build).