### PR TITLE
fix(hurricaneplan): correct outputFileTracingRoot for standalone Docker build

### DIFF
--- a/apps/web/hurricaneplan/next.config.ts
+++ b/apps/web/hurricaneplan/next.config.ts
@@ -7,7 +7,7 @@ const nextConfig: NextConfig = {
   reactCompiler: true,
   output: "standalone",
   ...(process.env.NODE_ENV === "production" && {
-    outputFileTracingRoot: fileURLToPath(new URL("../..", import.meta.url)),
+    outputFileTracingRoot: fileURLToPath(new URL("../../..", import.meta.url)),
     outputFileTracingIncludes: {
       "/**/*": ["./src/content/**/*.mdx"],
     },


### PR DESCRIPTION
Fix: outputFileTracingRoot was pointing to apps/ instead of monorepo root.