### PR TITLE
fix(hurricaneplan): await withContentCollections to preserve standalone output

### DIFF
--- a/apps/web/hurricaneplan/next.config.ts
+++ b/apps/web/hurricaneplan/next.config.ts
@@ -15,7 +15,9 @@ const nextConfig: NextConfig = {
   pageExtensions: ["js", "jsx", "ts", "tsx"],
 };
 
-export default withSentryConfig(withContentCollections(nextConfig), {
+const configWithCollections = await withContentCollections(nextConfig);
+
+export default withSentryConfig(configWithCollections, {
   org: "grenmet",
   project: process.env.SENTRY_PROJECT ?? "grenmet-staging",
   silent: !process.env.CI,

--- a/apps/web/hurricaneplan/next.config.ts
+++ b/apps/web/hurricaneplan/next.config.ts
@@ -15,13 +15,13 @@ const nextConfig: NextConfig = {
   pageExtensions: ["js", "jsx", "ts", "tsx"],
 };
 
-const configWithCollections = await withContentCollections(nextConfig);
-
-export default withSentryConfig(configWithCollections, {
-  org: "grenmet",
-  project: process.env.SENTRY_PROJECT ?? "grenmet-staging",
-  silent: !process.env.CI,
-  widenClientFileUpload: true,
-  disableLogger: true,
-  automaticVercelMonitors: false,
-});
+export default withContentCollections(nextConfig).then((config) =>
+  withSentryConfig(config as NextConfig, {
+    org: "grenmet",
+    project: process.env.SENTRY_PROJECT ?? "grenmet-staging",
+    silent: !process.env.CI,
+    widenClientFileUpload: true,
+    disableLogger: true,
+    automaticVercelMonitors: false,
+  })
+);


### PR DESCRIPTION
withContentCollections is async — passing its Promise directly to withSentryConfig caused output:standalone to be silently dropped.