### PR TITLE
fix(ci): production deploys via release or manual trigger only

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -3,56 +3,10 @@ name: Deploy to Production
 on:
   release:
     types: [ published ]
-  workflow_run:
-    workflows: [ "Build and Push Docker Images", "Build Web App Images" ]
-    types: [ completed ]
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:
-  # Guard: for workflow_run events both build workflows must have recently succeeded
-  # on main before we deploy. workflow_run fires once per workflow that finishes,
-  # so without this check the deploy could start with one stale image set.
-  check-builds:
-    runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'release' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
-    outputs:
-      ready: ${{ steps.check.outputs.ready }}
-    steps:
-      - name: Check both build workflows succeeded
-        id: check
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
-        with:
-          script: |
-            if (context.eventName !== 'workflow_run') {
-              core.setOutput('ready', 'true');
-              return;
-            }
-            const sha = context.payload.workflow_run.head_sha;
-            const branch = context.payload.workflow_run.head_branch;
-            const workflows = ['Build and Push Docker Images', 'Build Web App Images'];
-            for (const name of workflows) {
-              const { data } = await github.rest.actions.listWorkflowRunsForRepo({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                branch: branch,
-                per_page: 20,
-              });
-              const run = data.workflow_runs.find(r => r.name === name && r.head_sha === sha);
-              if (run && run.conclusion !== 'success') {
-                core.setOutput('ready', 'false');
-                return;
-              }
-              // No run for this sha means no relevant files changed — existing image is valid
-            }
-            core.setOutput('ready', 'true');
-
   deploy:
-    needs: check-builds
-    if: needs.check-builds.outputs.ready == 'true'
     runs-on: [ self-hosted, production ]
     timeout-minutes: 30
     environment:
@@ -67,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.3.1
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+          ref: ${{ github.ref }}
 
       - name: Setup environment
         env:


### PR DESCRIPTION
Remove workflow_run trigger from deploy-prod — production now only deploys on published release or manual workflow_dispatch.