### PR TITLE
Fix production backup workflow environment

### DIFF
--- a/.github/workflows/backup-database.yml
+++ b/.github/workflows/backup-database.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: [self-hosted, production]
     timeout-minutes: 30
     environment:
-      name: production
+      name: production-backup
     permissions:
       contents: read
     env:
       BACKUP_RETENTION_DAYS: 30
-      BACKUP_DIR: /home/github/backups
+      BACKUP_DIR: /var/backups/grenmet
 
     steps:
       - name: Verify database connectivity


### PR DESCRIPTION
Updates the production backup workflow to use the unprotected production-backup GitHub environment and write backups to /var/backups/grenmet.